### PR TITLE
Fix Site and Policy forum name typo

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 Board.create([
   { id: 2, title: 'General', description: '' },
-  { id: 9, title: 'Site and Policty', description: '' }
+  { id: 9, title: 'Site and Policy', description: '' }
 ])
 TagType.create([
   { id: 1, prefix: 'artist', hidden: 0 },


### PR DESCRIPTION
This commit corrects 'Policty' to 'Policy' in the Site and Policy forum name.