### PR TITLE
Scroll up on upload

### DIFF
--- a/app/assets/javascripts/components/uploader.js
+++ b/app/assets/javascripts/components/uploader.js
@@ -72,6 +72,7 @@ function Uploader() {
   this.form.addEventListener('submit', event => {
     if (!uploadingQueue) uploadingQueue = new UploadQueue();
     uploadingQueue.enqueue(this);
+    document.querySelectorAll('.tabs')[0].scrollIntoView();
     event.preventDefault();
   });
   

--- a/app/assets/javascripts/components/uploader.js
+++ b/app/assets/javascripts/components/uploader.js
@@ -72,7 +72,7 @@ function Uploader() {
   this.form.addEventListener('submit', event => {
     if (!uploadingQueue) uploadingQueue = new UploadQueue();
     uploadingQueue.enqueue(this);
-    document.querySelectorAll('.tabs')[0].scrollIntoView();
+    document.querySelector('.tabs').scrollIntoView();
     event.preventDefault();
   });
   


### PR DESCRIPTION
This commit remedies a bug where the user's scroll position stays out of bounds after hitting upload. The issue (only tested on Firefox) is caused by the video metadata editor having their elements hidden from view, and the browser not keeping up with that change.

I don't particularly like this fix, but I've barely been able to replicate the issue since.