### PR TITLE
Better center thumb tile links

### DIFF
--- a/app/assets/stylesheets/ui/thumbs/videos.css
+++ b/app/assets/stylesheets/ui/thumbs/videos.css
@@ -68,7 +68,7 @@ li.generic.mix .tile::after {
   line-height: 100%;
   color: #aaa;
   vertical-align: middle;
-  padding-top: 25%;
+  padding-top: 21%;
   text-decoration: none;
 }
 


### PR DESCRIPTION
This commit updates the padding-top for generic thumb tile links to better center the "View All x videos" text.

![1](https://user-images.githubusercontent.com/19217244/57764850-4a1af080-76d2-11e9-8433-bee796f9d71d.png) ![2](https://user-images.githubusercontent.com/19217244/57764858-4dae7780-76d2-11e9-9e6a-ee7e7a3764bf.png)


